### PR TITLE
Support multiple concurrent polygons

### DIFF
--- a/modules/moos_opgrid/opgrid_kml_writer.php
+++ b/modules/moos_opgrid/opgrid_kml_writer.php
@@ -57,7 +57,8 @@ class opgrid_kml_writer extends kml_writer
     }
 
 
-    function kml_viewplot($lat, $lon, $name)
+    // color = RGB hex code, alpha = [0, 1]
+    function kml_viewplot($lat, $lon, $name, $color, $alpha)
     {
         $this->push("Placemark", array("id"=>"viewplot_".$name));
         $this->element("name", $name);
@@ -73,6 +74,15 @@ class opgrid_kml_writer extends kml_writer
         
         $this->pop();
         $this->pop();
+
+
+        $this->push("Style");
+        $this->push("LineStyle");
+        $this->element("width", "0.5");
+        $this->element("color", sprintf("%02X", $alpha*255).$color);
+        $this->pop();
+        $this->pop();
+
         $this->pop();
         //$this->kml_opbox_label($name, $lat[0], $lon[0], "ffffffff", "viewplot_label_".$name);
         


### PR DESCRIPTION
allow multiple polygons with different labels to be shown concurrently for a given vehicle.

Requires:

```
mysql -u root -p
```

```
USE geov_moos_opgrid;

ALTER TABLE `moos_opgrid_profile_vehicle` CHANGE `p_vehicle_viewpolygon`
`p_vehicle_viewpolygon` TEXT CHARACTER SET utf8 COLLATE utf8_unicode_ci
NULL DEFAULT NULL;
```

